### PR TITLE
any 타입 EditorState로 수정

### DIFF
--- a/src/components/editor/Editor.tsx
+++ b/src/components/editor/Editor.tsx
@@ -7,6 +7,7 @@ import Placeholder from './Placeholder'
 import { IMemos } from '../../utils/types'
 import { useLexicalComposerContext } from '@lexical/react/LexicalComposerContext'
 import { EMPTY_CONTENT } from '../../utils/constants'
+import { EditorState } from 'lexical'
 interface IEditorProps {
   focusedMemoId: number
   memos: IMemos[]
@@ -20,9 +21,9 @@ export default function Editor({ focusedMemoId, memos, editMemos }: IEditorProps
     editor.setEditorState(editorState);
   }, [focusedMemoId, memos])
 
-  const onChange = (editorState: any) => {
-    const { root } = editorState.toJSON();
-    const nodes = root.children[0].children
+  const onChange = (editorState: EditorState) => {
+    const childJSON = editorState.toJSON().root.children[0] as unknown as { children: [{ text: string, type: string }] }
+    const nodes = childJSON.children
     const titleIndex = nodes.findIndex(({ type }: { type: string }) => type === 'text')
 
     if (nodes[titleIndex]?.text) {


### PR DESCRIPTION
# any 타입 제거하기
## 기존 코드
![code](https://github.com/khw970421/rmsoft/assets/59253551/47e66bc1-6733-4e3f-ba9e-2992e12df55d)
과제 해결 사항 : 메모 목록에서 메모 내용의 첫번째 줄이 메모의 제목으로 표시 되어야 합니다.
* 이를 위한 title을 찾기 위해 `toJSON`을 이용하여 동작은 정상적으로 되나 타입에서 `EditorState`로 처리하니 문제가 발생했었다.

## 문제 원인
`EditorState`타입인 `editor`를 `editorState.toJSON()`을하게되면 `SerializedEditorState` 타입으로 바뀌게 된다.

```js
export interface SerializedEditorState<T extends SerializedLexicalNode = SerializedLexicalNode> {
    root: SerializedRootNode<T>;
}
```

`SerializedEditorState` 타입의 root로 접근하게 되면 `SerializedRootNode<T>` 타입을 얻는다.
```js
export type SerializedLexicalNode = {
    type: string;
    version: number;
};
```
*  `SerializedRootNode<T>` 타입은 type과 version을 갖고 있다고 적혀있다. 
하지만 실제로 다른 프로퍼티도 포함되어 있다. 


<img width="788" alt="image" src="https://github.com/khw970421/rmsoft/assets/59253551/b0e316ea-36e8-45e2-90bf-5d9184c7febc">

* 즉, 필요한 children 프로퍼티를 접근하고 싶어도 타입스크립트에서 존재하지 않는 프로퍼티에 접근하므로 타입 에러가 발생하는 부분이 생겨 이 부분을 any 대신 바꾸려고한다.

## 해결 하기 - any 대신 editorState를 사용하고 필요한 부분에 `as unknown as type` 처리
![code](https://github.com/khw970421/rmsoft/assets/59253551/07c81d98-5e66-4531-b1ee-f68aca17d2ed)
* 필요한 부분의 `children` 프로퍼티를 추가하여 필요한 접근에 에러가 발생하지 않도록 처리한다. 

## 좀 더 고민하기
* any를 사용하는 것을 지양하기 위해 이러한 탐색과 as unknown 처리를 했지만 더 좋은 방법은 무엇인지 생각해봐야한다.
 