### PR TITLE
debounce edit 기능 취소

### DIFF
--- a/src/components/editor/Editor.tsx
+++ b/src/components/editor/Editor.tsx
@@ -10,7 +10,7 @@ import Placeholder from './Placeholder'
 
 import { IMemos } from '../../utils/types'
 import { EMPTY_CONTENT } from '../../utils/constants'
-import debounce from '../../utils/debounce'
+
 interface IEditorProps {
   focusedMemoId: number
   memos: IMemos[]
@@ -24,13 +24,11 @@ export default function Editor({ focusedMemoId, memos, editMemos }: IEditorProps
     editor.setEditorState(editorState);
   }, [focusedMemoId, memos])
 
-  const debounceEditMemos = debounce(editMemos)
   const onChange = (editorState: EditorState) => {
     const childJSON = editorState.toJSON().root.children[0] as unknown as { children: [{ text: string, type: string }] }
     const nodes = childJSON.children
     const titleIndex = nodes.findIndex(({ type }: { type: string }) => type === 'text')
-
-    debounceEditMemos({ title: nodes[titleIndex]?.text, content: JSON.stringify(editorState.toJSON()) })
+    editMemos({ title: nodes[titleIndex]?.text, content: JSON.stringify(editorState.toJSON()) })
   }
 
   return (


### PR DESCRIPTION
# 처음 Debounce를 사용하고자 했던 이유
* input의 한글자씩 수정이 될때마다 이로인해 savedNotebooks가 바뀌며 불필요한 리렌더링이 자주 발생하는 것을 막기 위해서

# Debounce로 수정시 문제점 
1. 수정을 진행중에 memo를 추가하거나 삭제한다.
2. 수정부분은 setTimeout에 의해 추가나 삭제가 먼저 진행된다. 
3. 추가나 삭제로 인한 focusedMemoId가 수정할때와 달라진다.
4. 이후 수정을 진행하는데 달라진 focusedMemoId로 인해 의도한 결과를 얻을 수 없다. 
